### PR TITLE
Updated expected Bachelors program page slug

### DIFF
--- a/includes/form-population.php
+++ b/includes/form-population.php
@@ -102,7 +102,7 @@ if ( ! function_exists( 'ou_forms_populate_degrees' ) ) {
 			if ( $post && $post->post_type === 'page' ) {
 				// Force filtered results on specific pages:
 				switch ( $post->post_name ) {
-					case 'majors':
+					case 'bachelors':
 						$args = ou_append_degrees_tax_query( $args, 'online-major' );
 						break;
 					case 'doctorates':


### PR DESCRIPTION
The /majors/ programs page slug is changing to /bachelors/; this update ensures the page-specific degree form overrides account for the change (so selectable degrees in the "Request Information" form only include bachelors programs).