### PR TITLE
Modify align options for labels

### DIFF
--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -101,7 +101,7 @@ function ou_remove_right_aligned_labels( $settings, $form ) {
 <?php
 	$tr_form_label_placement = ob_get_clean();
 
-	$settings['Form Layout']['form_label_placement'] = $tr_form_label_placement;
+	$settings[ __( 'Form Layout', 'gravityforms' ) ]['form_label_placement'] = $tr_form_label_placement;
 
 	return $settings;
 }

--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -76,8 +76,6 @@ function ou_remove_right_aligned_labels( $settings, $form ) {
 	// Default to left_label if the value is right_label
 	$selected_value = ( $selected_value === 'right_label' ) ? 'left_label' : $selected_value;
 
-	var_dump( $selected_value );
-
 	$alignment_options = array(
 		'top_label'  => __( 'Top aligned', 'gravityforms' ),
 		'left_label' => __( 'Left aligned', 'gravityforms' )

--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -59,3 +59,53 @@ function ou_add_privacy_policy( $input, $form ) {
 }
 add_action( 'gform_submit_button', 'ou_add_privacy_policy', 10, 2 );
 add_action( 'gform_next_button', 'ou_add_privacy_policy', 10, 2 );
+
+/**
+ * Remove right aligned labels from gravity form options
+ * @author Jim Barnes
+ * @since 2.0.1
+ * @param array $settings The settings array for the form
+ * @param array $form The current settings for the form
+ * @return array The modified $settings array
+ */
+function ou_remove_right_aligned_labels( $settings, $form ) {
+	$tr_form_label_placement = '';
+
+	$selected_value = $form['labelPlacement'];
+
+	// Default to left_label if the value is right_label
+	$selected_value = ( $selected_value === 'right_label' ) ? 'left_label' : $selected_value;
+
+	var_dump( $selected_value );
+
+	$alignment_options = array(
+		'top_label'  => __( 'Top aligned', 'gravityforms' ),
+		'left_label' => __( 'Left aligned', 'gravityforms' )
+	);
+
+	ob_start();
+?>
+	<tr>
+		<th>
+			<?php echo __( 'Label placement', 'gravityforms' ); ?>
+			<?php echo gform_tooltip( 'form_label_placement', '', true ); ?>
+		</th>
+		<td>
+			<select id="form_label_placement" name="form_label_placement" onchange="UpdateLabelPlacement();">
+			<?php foreach( $alignment_options as $value => $label ) : ?>
+				<option value="<?php echo $value; ?>"<?php echo ( $selected_value === $value ) ? ' selected=""' : ''; ?>>
+					<?php echo $label; ?>
+				</option>
+			<?php endforeach; ?>
+			</select>
+		</td>
+	</tr>
+<?php
+	$tr_form_label_placement = ob_get_clean();
+
+	$settings['Form Layout']['form_label_placement'] = $tr_form_label_placement;
+
+	return $settings;
+}
+
+add_filter( 'gform_form_settings', 'ou_remove_right_aligned_labels', 10, 2 );


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes the Right aligned (`right_label`) option from the Label Placement option for gravity forms.

**Motivation and Context**
Right aligned labels will not be used for UCF Online and there are no defined styles for right aligned labels. See #10 .

**How Has This Been Tested?**
Changes are in dev and can be reviewed there. A specific link will be posted in slack.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
