### PR TITLE
Privacy policy link markup; form inputs to buttons

### DIFF
--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -67,6 +67,38 @@ add_filter( 'do_shortcode_tag', 'ou_add_privacy_policy', 10, 2 );
 
 
 /**
+ * Filters the next, previous and submit buttons.
+ * Replaces the forms <input> buttons with <button> while maintaining attributes from original <input>.
+ *
+ * https://www.gravityhelp.com/documentation/article/gform_submit_button/
+ *
+ * Ported from Online-Theme
+ *
+ * @param string $button Contains the <input> tag to be filtered.
+ * @param object $form Contains all the properties of the current form.
+ *
+ * @return string The filtered button.
+ */
+function ou_input_to_button( $button, $form ) {
+	$dom = new DOMDocument();
+	$dom->loadHTML( $button );
+	$input = $dom->getElementsByTagName( 'input' )->item(0);
+	$new_button = $dom->createElement( 'button' );
+	$value = $dom->createTextNode( $input->getAttribute( 'value' ) );
+	$new_button->appendChild( $value );
+	$input->removeAttribute( 'value' );
+	foreach( $input->attributes as $attribute ) {
+		$new_button->setAttribute( $attribute->name, $attribute->value );
+	}
+	$input->parentNode->replaceChild( $new_button, $input );
+	return $dom->saveHTML();
+}
+add_filter( 'gform_next_button', 'ou_input_to_button', 10, 2 );
+add_filter( 'gform_previous_button', 'ou_input_to_button', 10, 2 );
+add_filter( 'gform_submit_button', 'ou_input_to_button', 10, 2 );
+
+
+/**
  * Remove right aligned labels from gravity form options
  * @author Jim Barnes
  * @since 2.0.1

--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -74,6 +74,7 @@ add_filter( 'do_shortcode_tag', 'ou_add_privacy_policy', 10, 2 );
  *
  * Ported from Online-Theme
  *
+ * @since 2.0.1
  * @param string $button Contains the <input> tag to be filtered.
  * @param object $form Contains all the properties of the current form.
  *

--- a/includes/form-functions.php
+++ b/includes/form-functions.php
@@ -47,18 +47,24 @@ add_filter( 'gform_confirmation_anchor', '__return_false' );
  * @param object $form The form currently being processed.
  * @return string
  */
-function ou_add_privacy_policy( $input, $form ) {
+function ou_add_privacy_policy( $output, $tag ) {
+	if ( 'gravityform' !== $tag ) {
+		return $output;
+	}
+
 	ob_start();
 ?>
-	<div>
-		<p class="mb-0 mt-3 pull-right small"><a class="privacy-policy-link" href="#" onclick="window.open('https://www.ucf.edu/internet-privacy-policy/','Internet Privacy Policy','resizable,height=750,width=768'); return false;">Privacy Policy</a></p>
+	<div class="d-flex flex-row justify-content-end w-100 mt-3">
+		<p class="mb-0 small"><a class="privacy-policy-link" href="#" onclick="window.open('https://www.ucf.edu/internet-privacy-policy/','Internet Privacy Policy','resizable,height=750,width=768'); return false;">Privacy Policy</a></p>
 	</div>
-	<div class="clearfix"></div>
 <?php
-	return $input . ob_get_clean();
+	$policy_link = ob_get_clean();
+
+	return $output . $policy_link;
 }
-add_action( 'gform_submit_button', 'ou_add_privacy_policy', 10, 2 );
-add_action( 'gform_next_button', 'ou_add_privacy_policy', 10, 2 );
+
+add_filter( 'do_shortcode_tag', 'ou_add_privacy_policy', 10, 2 );
+
 
 /**
  * Remove right aligned labels from gravity form options


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated markup for the injected privacy policy links on forms and moved them to be injected after the entire form, as opposed to within the form's footer.
- Re-added snippet from Online-Theme that converts form previous, next, and submit buttons to actual `<button>` elements to allow for styling in the Online-Child-Theme using `:before`/`:after`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for updated in the Online-Child-Theme related to multipage prev/next form styling.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
