### PR TITLE
Quieting a php notice about variables being passed by reference

### DIFF
--- a/includes/form-population.php
+++ b/includes/form-population.php
@@ -220,7 +220,8 @@ if ( ! function_exists( 'ou_forms_set_dynamic_vals' ) ) {
 			$degree_contact_email = get_post_meta( $degree->ID, 'degree_contact_email', true );
 			$degree_code = get_post_meta( $degree->ID, 'degree_code', true );
 			$degree_subplan_code = get_post_meta( $degree->ID, 'degree_subplan_code', true );
-			$degree_program_type  = array_shift( wp_get_post_terms( $degree->ID, 'program_types' ) );
+			$program_types = wp_get_post_terms( $degree->ID, 'program_types' );
+			$degree_program_type  = array_shift( $program_types );
 		}
 
 		if ( !$degree_contact_email ) {


### PR DESCRIPTION
<!---
Thank you for contributing to Online-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Online-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
`array_shift` accesses the array passed in by reference, and PHP in general doesn't like return values of functions to passed in by reference, preferring a variable be passed. This squashes the warning thrown by setting the `program_types` to a variable before passing it to `array_shift`.

**Motivation and Context**
We don't like php warnings.

**How Has This Been Tested?**
Can be tested in dev by submitting a "Request Information" form. You should not see any errors pop up before being redirected to a confirmation page.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
